### PR TITLE
Update fcc packages for 94.2.0

### DIFF
--- a/packages/fcc-edm/package.py
+++ b/packages/fcc-edm/package.py
@@ -32,6 +32,7 @@ class FccEdm(CMakePackage):
     homepage = "https://github.com/HEP-FCC/fcc-edm"
     url      = "https://github.com/HEP-FCC/fcc-edm/archive/v0.5.1.tar.gz"
 
+    version('0.5.4', '236206ca4e00f239d574bfcd6aa44b53')
     version('0.5.3', 'ce4e041c795a22e7a6b4558ebe5a9545')
     version('0.5.2', '8f17139fae2bbc14fca88843791be9c3')
     version('0.5.1', '99aea85185a2afdf1f4eb6c24e7d9e74')

--- a/packages/papas/package.py
+++ b/packages/papas/package.py
@@ -31,8 +31,9 @@ class Papas(CMakePackage):
     test the performance of detector design."""
 
     homepage = "https://github.com/HEP-FCC/papas"
-    url      = "https://github.com/HEP-FCC/papas/archive/1.2.0.tar.gz"
+    url      = "https://github.com/HEP-FCC/papas/archive/1.2.1.tar.gz"
 
+    version('1.2.1', '78f34649bd7b82aa1e8eb27b69dae8d1')
     version('1.2.0', '74d700ca5872872b2beda7e5862bfaa4')
     version('develop', git='https://github.com/HEP-FCC/papas.git', branch='master')
 

--- a/packages/podio/package.py
+++ b/packages/podio/package.py
@@ -30,10 +30,11 @@ class Podio(CMakePackage):
     and handling of data models in particle physics."""
 
     homepage = "https://github.com/HEP-FCC/podio"
-    url      = "https://github.com/HEP-FCC/podio/archive/v0.8.tar.gz"
+    url      = "https://github.com/HEP-FCC/podio/archive/v0.9.1.tar.gz"
 
+    version('0.9.1', '9e2b8cf6d2be46d74471ae4857bd7191', preferred=True)
     version('0.8', '07bf090649fc8e3b94e348e6b7fb8c7e')
-    version('0.7', '79e11c02c8d588f7b1dfc39b7de4eed9', preferred=True)
+    version('0.7', '79e11c02c8d588f7b1dfc39b7de4eed9')
     version('0.6', '1a1d2aa70fc16cce372ce10c3612c32d')
     version('develop', git='https://github.com/HEP-FCC/podio.git', branch='master')
 

--- a/packages/tricktrack/package.py
+++ b/packages/tricktrack/package.py
@@ -30,15 +30,48 @@ class Tricktrack(CMakePackage):
     used in CMSSW in a standalone library."""
 
     homepage = "https://cern.ch/tricktrack"
-    url      = "https://github.com/HEP-SF/TrickTrack/archive/v1.0.6.tar.gz"
+    url      = "https://github.com/HEP-SF/TrickTrack/archive/v1.0.8.tar.gz"
+    git      = "https://github.com/HEP-SF/TrickTrack.git"
 
+    version('develop', branch='master')
+    version('1.0.8', '014561e6be35f9b858dad8f9158c4746')
+    version('1.0.7', '93573819088d0dee7c3a260d7c8a8a61')
     version('1.0.6', 'ef8cc9d5d9760935da2ef56aa98d9885')
     version('1.0.5', '65493aa89361c139c28f63b473459312')
     version('1.0.4', '7fefd2f94c4925d307897b483b9eb039')
     version('1.0.1', 'ec23cadf8b7fa4a343e513c7c988e27f')
     version('0.1',   'a75c6e2c7d7df5b713aa087827503e3c')
 
+    variant('documentation',     default=False, 
+            description='Build doxygen documentation')
+    variant('python',            default=False, 
+            description='Build python bindings')
+    variant('logger',            default=False, 
+            description='Use spdlog for logging')
+    variant('logger_standalone', default=False, 
+            description='Use spdlog standalone (as opposed to in a framework)')
+
+    depends_on('doxygen', when="+documentation")
+    depends_on('spdlog', when="+logger")
     depends_on('eigen', when="@1.0.4:")
+    depends_on('python', when="+python", type=('run'))
 
     patch('eigen.patch', when="@1.0.4")
     patch('findeigen.patch', when="@1.0.4")
+
+    def cmake_args(self):
+	spec = self.spec
+
+	args = [
+	    '-Dtricktrack_documentation:BOOL=%s' % (
+		'ON' if '+documentation' in spec else 'OFF'),
+	    '-Dtricktrack_python:BOOL=%s' % (
+		'ON' if '+python' in spec else 'OFF'),
+	]
+
+	if '+logger' in spec:
+	    args.extend(['-DUSE_SPDLOG'])
+	if '+logger_standalone' in spec:
+	    args.extend(['-DUSE_SPDLOG_STANDALONE'])
+
+	return args


### PR DESCRIPTION
- `papas`: Add new version 1.2.1
- `podio`: Add new version 0.9.1
- `fcc-edm`: Add new version: 0.5.4
- `tricktrack`: 
    + Add new versions  (1.0.7, 1.0.8, develop)
    + Add CMake options