### PR TITLE
Update FCChhAnalyses

### DIFF
--- a/packages/fccdevel/package.py
+++ b/packages/fccdevel/package.py
@@ -44,6 +44,7 @@ class Fccdevel(PackageBase):
     depends_on('fcc-edm@develop cxxstd=17', when="%gcc@7:")
     depends_on('fcc-edm cxxstd=14', when="%gcc@:6.99")
 
+    depends_on('py-fcchhanalyses')
     depends_on('fcc-physics')
     depends_on('gaudi')
     depends_on('geant4')

--- a/packages/py-fcchhanalyses/package.py
+++ b/packages/py-fcchhanalyses/package.py
@@ -31,7 +31,7 @@ class PyFcchhanalyses(PythonPackage):
     homepage = "https://github.com/HEP-FCC/FCChhAnalyses"
     git      = "https://github.com/HEP-FCC/FCChhAnalyses"
 
-    version('0.1.0', tag='v0.1.0')
+    version('0.1.1', tag='v0.1.1')
 
     depends_on('py-setuptools',   type='build')
     depends_on('py-wheel',        type='build')


### PR DESCRIPTION
- Replace version: 0.1.1 to replace 0.1.0 which does not work as
expected
- Add py-fcchhanalyses (name of FCChhAnalyses in Spack) as a dependency
of fccdevel

This PR requires this [FCChhAnalyses PR](https://github.com/HEP-FCC/FCChhAnalyses/pull/3) and the corresponding new tag `0.1.1`.